### PR TITLE
Move debug logic to separate package

### DIFF
--- a/cached_item.go
+++ b/cached_item.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"math/rand/v2"
 	"sync"
+
+	debuginternal "github.com/go418/concurrentcache/internal/debug"
 )
 
 type CachedItem[V any] struct {
@@ -45,7 +47,7 @@ func NewCachedItem[V any](generateMissingValue GenerateMissingItemValueFunc[V]) 
 }
 
 func (c *CachedItem[V]) Get(ctx context.Context, minVersion CacheVersion) Result[V] {
-	debugger := debuggerFromContext(ctx)
+	debugger := debuginternal.DebuggerFromContext(ctx)
 
 	c.mu.Lock()
 	item := c

--- a/cached_map.go
+++ b/cached_map.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"math/rand/v2"
 	"sync"
+
+	debuginternal "github.com/go418/concurrentcache/internal/debug"
 )
 
 type CachedMap[K comparable, V any] struct {
@@ -48,7 +50,7 @@ func NewCachedMap[K comparable, V any](generateMissingValue GenerateMissingMapVa
 }
 
 func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersion) Result[V] {
-	debugger := debuggerFromContext(ctx)
+	debugger := debuginternal.DebuggerFromContext(ctx)
 
 	c.mu.Lock()
 	item := c.items[key]

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -14,33 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package concurrentcache
+package debug
 
-import "context"
+import (
+	debuginternal "github.com/go418/concurrentcache/internal/debug"
+)
 
-type debugKey struct{}
-
-type debugFns struct {
-	onStartedWaiting func()
-}
-
-func (d *debugFns) OnStartedWaiting() {
-	if d == nil || d.onStartedWaiting == nil {
-		return
-	}
-
-	d.onStartedWaiting()
-}
-
-func OnStartedWaiting(ctx context.Context, onStartedWaiting func()) context.Context {
-	return context.WithValue(ctx, debugKey{}, debugFns{
-		onStartedWaiting: onStartedWaiting,
-	})
-}
-
-func debuggerFromContext(ctx context.Context) *debugFns {
-	if v, ok := ctx.Value(debugKey{}).(debugFns); ok {
-		return &v
-	}
-	return nil
-}
+// OnStartedWaiting is a callback that is called when a Get operation starts
+// waiting for the generator function to finish. This should only be used for
+// debugging purposes and is subject to change.
+var OnStartedWaiting = debuginternal.OnStartedWaiting

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 The go418 authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debuginternal
+
+import "context"
+
+type debugKey struct{}
+
+type debugFns struct {
+	onStartedWaiting func()
+}
+
+func (d *debugFns) OnStartedWaiting() {
+	if d == nil || d.onStartedWaiting == nil {
+		return
+	}
+
+	d.onStartedWaiting()
+}
+
+func OnStartedWaiting(ctx context.Context, onStartedWaiting func()) context.Context {
+	return context.WithValue(ctx, debugKey{}, debugFns{
+		onStartedWaiting: onStartedWaiting,
+	})
+}
+
+func DebuggerFromContext(ctx context.Context) *debugFns {
+	if v, ok := ctx.Value(debugKey{}).(debugFns); ok {
+		return &v
+	}
+	return nil
+}

--- a/test/cached_item_test.go
+++ b/test/cached_item_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"concurrentcache"
+	"github.com/go418/concurrentcache"
+	"github.com/go418/concurrentcache/debug"
 )
 
 // The multiple Get calls for the same key should result in a single generateMissingValue call.
@@ -238,7 +239,7 @@ func testItemGet(
 	for expectedCount := 1; expectedCount <= nrRepeats; expectedCount++ {
 		startingGetCalls := nrConcurrentGetCalls
 		allWaiting := make(chan struct{}) // Block until all Get calls are waiting.
-		debugContext := concurrentcache.OnStartedWaiting(rootCtx, func() {
+		debugContext := debug.OnStartedWaiting(rootCtx, func() {
 			startingGetCalls--
 
 			if startingGetCalls == 0 {

--- a/test/cached_map_test.go
+++ b/test/cached_map_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"concurrentcache"
+	"github.com/go418/concurrentcache"
+	"github.com/go418/concurrentcache/debug"
 )
 
 type returnValue struct {
@@ -314,7 +315,7 @@ func testMapGet(
 			for expectedCount := 1; expectedCount <= nrRepeats; expectedCount++ {
 				startingGetCalls := nrConcurrentGetCalls
 				allWaiting := make(chan struct{}) // Block until all Get calls are waiting.
-				debugContext := concurrentcache.OnStartedWaiting(rootCtx, func() {
+				debugContext := debug.OnStartedWaiting(rootCtx, func() {
 					startingGetCalls--
 
 					if startingGetCalls == 0 {

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,10 +2,10 @@ module test
 
 go 1.22.5
 
-replace concurrentcache => ../
+replace github.com/go418/concurrentcache => ../
 
 require (
-	concurrentcache v0.0.0-00010101000000-000000000000
+	github.com/go418/concurrentcache v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.7.0
 )


### PR DESCRIPTION
This will make the docs less confusing, since most users should not be concerned with the debug logic.
We only use the debug logic for testing atm.