### PR TITLE
Allow direct struct construction

### DIFF
--- a/cached_item.go
+++ b/cached_item.go
@@ -30,19 +30,19 @@ type CachedItem[V any] struct {
 	// This value is 0 until the first generator function call starts executing.
 	itemId uint64
 
-	mu                   sync.Mutex
-	generateMissingValue GenerateMissingItemValueFunc[V]
-	cachedValue          versionedValue[V]
-	worker               *cacheWorker[V]
+	mu          sync.Mutex
+	cachedValue versionedValue[V]
+	worker      *cacheWorker[V]
+
+	// Generator function that is called when the cached value is missing or out-of-date.
+	GenerateMissingValue GenerateMissingItemValueFunc[V]
 }
 
 type GenerateMissingItemValueFunc[V any] func(ctx context.Context) (V, error)
 
 func NewCachedItem[V any](generateMissingValue GenerateMissingItemValueFunc[V]) *CachedItem[V] {
 	return &CachedItem[V]{
-		itemId: rand.Uint64(),
-
-		generateMissingValue: generateMissingValue,
+		GenerateMissingValue: generateMissingValue,
 	}
 }
 
@@ -163,7 +163,7 @@ func (c *CachedItem[V]) Get(ctx context.Context, minVersion CacheVersion) Result
 
 func (c *CachedItem[V]) run(ctx context.Context, worker *cacheWorker[V]) {
 	defer close(worker.done)
-	result, error := c.generateMissingValue(ctx)
+	result, error := c.GenerateMissingValue(ctx)
 
 	// set the result on the worker
 	worker.cachedValue.value = result

--- a/cached_item.go
+++ b/cached_item.go
@@ -35,14 +35,14 @@ type CachedItem[V any] struct {
 	worker      *cacheWorker[V]
 
 	// Generator function that is called when the cached value is missing or out-of-date.
-	GenerateMissingValue GenerateMissingItemValueFunc[V]
+	Generate GenerateMissingItemValueFunc[V]
 }
 
 type GenerateMissingItemValueFunc[V any] func(ctx context.Context) (V, error)
 
 func NewCachedItem[V any](generateMissingValue GenerateMissingItemValueFunc[V]) *CachedItem[V] {
 	return &CachedItem[V]{
-		GenerateMissingValue: generateMissingValue,
+		Generate: generateMissingValue,
 	}
 }
 
@@ -163,7 +163,7 @@ func (c *CachedItem[V]) Get(ctx context.Context, minVersion CacheVersion) Result
 
 func (c *CachedItem[V]) run(ctx context.Context, worker *cacheWorker[V]) {
 	defer close(worker.done)
-	result, error := c.GenerateMissingValue(ctx)
+	result, error := c.Generate(ctx)
 
 	// set the result on the worker
 	worker.cachedValue.value = result

--- a/cached_map.go
+++ b/cached_map.go
@@ -30,7 +30,7 @@ type CachedMap[K comparable, V any] struct {
 	items map[K]cacheItem[V]
 
 	// Generator function that is called when the cached value is missing or out-of-date.
-	GenerateMissingValue GenerateMissingMapValueFunc[K, V]
+	Generate GenerateMissingMapValueFunc[K, V]
 }
 
 type cacheItem[V any] struct {
@@ -46,8 +46,8 @@ type GenerateMissingMapValueFunc[K comparable, V any] func(ctx context.Context, 
 
 func NewCachedMap[K comparable, V any](generateMissingValue GenerateMissingMapValueFunc[K, V]) *CachedMap[K, V] {
 	return &CachedMap[K, V]{
-		GenerateMissingValue: generateMissingValue,
-		items:                make(map[K]cacheItem[V]),
+		Generate: generateMissingValue,
+		items:    make(map[K]cacheItem[V]),
 	}
 }
 
@@ -172,7 +172,7 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 
 func (c *CachedMap[K, V]) run(ctx context.Context, worker *cacheWorker[V], key K) {
 	defer close(worker.done)
-	result, error := c.GenerateMissingValue(ctx, key)
+	result, error := c.Generate(ctx, key)
 
 	// set the result on the worker
 	worker.cachedValue.value = result

--- a/test/cached_item_test.go
+++ b/test/cached_item_test.go
@@ -53,6 +53,31 @@ func TestItemMultiple(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+// The cache should be constructable directly (without calling NewCachedItem).
+func TestItemConstructable(t *testing.T) {
+	rootCtx := context.Background()
+
+	count := 0
+	cache := concurrentcache.CachedItem[returnValue]{
+		GenerateMissingValue: func(ctx context.Context) (returnValue, error) {
+			count++
+			return returnValue{
+				count: count,
+			}, nil
+		},
+	}
+
+	for i := 0; i < 10; i++ {
+		result := cache.Get(rootCtx, concurrentcache.AnyVersion)
+		require.Equal(t, returnValue{count: 1}, result.Value)
+		require.NoError(t, result.Error)
+		require.Equal(t, i > 0, result.FromCache)
+	}
+
+	// Check that the values were only created once.
+	require.Equal(t, 1, count)
+}
+
 // An error returned by generateMissingValue should be cached similarly to a valid value.
 func TestItemError(t *testing.T) {
 	rootCtx := context.Background()

--- a/test/cached_item_test.go
+++ b/test/cached_item_test.go
@@ -59,7 +59,7 @@ func TestItemConstructable(t *testing.T) {
 
 	count := 0
 	cache := concurrentcache.CachedItem[returnValue]{
-		GenerateMissingValue: func(ctx context.Context) (returnValue, error) {
+		Generate: func(ctx context.Context) (returnValue, error) {
 			count++
 			return returnValue{
 				count: count,

--- a/test/cached_map_test.go
+++ b/test/cached_map_test.go
@@ -110,7 +110,7 @@ func TestMapConstructable(t *testing.T) {
 
 	counts := map[string]int{}
 	cache := concurrentcache.CachedMap[string, returnValue]{
-		GenerateMissingValue: func(ctx context.Context, key string) (returnValue, error) {
+		Generate: func(ctx context.Context, key string) (returnValue, error) {
 			counts[key]++
 			return returnValue{
 				requestedKey: key,


### PR DESCRIPTION
Make it possible for `CachedMap` and `CachedItem` to be constructed directly without calling `NewCachedMap` or `NewCachedItem`.

Now, caches can be constructed in two different ways:
```go
cache := concurrentcache.NewCachedItem(func(ctx context.Context) (returnValue, error) {
	count++
	return returnValue{
		count: count,
	}, nil
})
```
or
```go
cache := concurrentcache.CachedItem[returnValue]{
      Generate: func(ctx context.Context) (returnValue, error) {
	      count++
	      return returnValue{
		      count: count,
	      }, nil
      },
}
```