### PR TITLE
Global versioning

### DIFF
--- a/cached.go
+++ b/cached.go
@@ -16,20 +16,16 @@ limitations under the License.
 
 package concurrentcache
 
-type CacheVersion struct {
-	version uint64
-	itemId  uint64
+import "sync/atomic"
+
+var globalVersion atomic.Uint64
+
+func newVersion() CacheVersion {
+	return CacheVersion{version: globalVersion.Add(1)}
 }
 
-func (cv CacheVersion) matchesItem(itemId uint64) bool {
-	// If the itemId in CacheVersion is 0, we are working with a general case
-	// version (eg. AnyVersion or NonCachedVersion) these work for all items.
-	if cv.itemId == 0 {
-		return true
-	}
-
-	// Make sure the itemIds match
-	return cv.itemId == itemId
+type CacheVersion struct {
+	version uint64
 }
 
 var (
@@ -82,7 +78,7 @@ func (vv versionedValue[V]) newer() CacheVersion {
 	return CacheVersion{version: vv.version + 1}
 }
 
-func (vv versionedValue[V]) toResult(itemId uint64, isFromCache bool) Result[V] {
+func (vv versionedValue[V]) toResult(isFromCache bool) Result[V] {
 	return Result[V]{
 		Value:     vv.value,
 		Error:     vv.err,
@@ -90,10 +86,7 @@ func (vv versionedValue[V]) toResult(itemId uint64, isFromCache bool) Result[V] 
 
 		// For a result that is from the cache, the NextVersion is the version
 		// of the result plus one, making it newer than the current version.
-		NextVersion: CacheVersion{
-			itemId:  itemId,
-			version: vv.version + 1,
-		},
+		NextVersion: vv.newer(),
 	}
 }
 

--- a/cached_map.go
+++ b/cached_map.go
@@ -19,7 +19,6 @@ package concurrentcache
 import (
 	"context"
 	"errors"
-	"math/rand/v2"
 	"sync"
 
 	debuginternal "github.com/go418/concurrentcache/internal/debug"
@@ -37,10 +36,6 @@ type CachedMap[K comparable, V any] struct {
 }
 
 type cacheItem[V any] struct {
-	// Unique identifier for this item, used to make sure CacheVersions correspond to this item.
-	// This value is 0 until the first generator function call starts executing.
-	itemId uint64
-
 	cachedValue versionedValue[V]
 	worker      *cacheWorker[V]
 }
@@ -73,18 +68,13 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 	}
 	item := c.items[key]
 
-	if !minVersion.matchesItem(item.itemId) {
-		c.mu.Unlock()
-		panic("[programming error]: provided minVersion does not correspond to the current (cache, key) combo; don't mix CacheVersions across items")
-	}
-
 	var nextVersion CacheVersion
 	// Return the cached value if it is at least as new as the minimum version.
 	{
 		cachedValue := item.cachedValue
 		if !cachedValue.isZero() && cachedValue.hasMinimumVersion(minVersion) {
 			defer c.mu.Unlock() // Unlock after reading the cached value.
-			return cachedValue.toResult(item.itemId, true)
+			return cachedValue.toResult(true)
 		}
 		nextVersion = cachedValue.newer()
 	}
@@ -115,14 +105,9 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 	if worker == nil {
 		workerCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
 
-		// If the item does not have an itemId, generate a random one.
-		if item.itemId == 0 {
-			item.itemId = rand.Uint64()
-		}
-
 		worker = &cacheWorker[V]{
 			cachedValue: versionedValue[V]{
-				version: nextVersion.version,
+				version: newVersion().version,
 			},
 
 			cancel:            cancel,
@@ -180,7 +165,7 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 	case <-worker.done: // The worker has finished.
 	}
 
-	return worker.cachedValue.toResult(item.itemId, false)
+	return worker.cachedValue.toResult(false)
 }
 
 func (c *CachedMap[K, V]) run(ctx context.Context, worker *cacheWorker[V], key K) {

--- a/test/cached_item_test.go
+++ b/test/cached_item_test.go
@@ -102,34 +102,6 @@ func TestItemError(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
-func TestItemPanic(t *testing.T) {
-	rootCtx := context.Background()
-
-	cache1 := concurrentcache.NewCachedItem(func(ctx context.Context) (bool, error) {
-		return true, nil
-	})
-
-	cache2 := concurrentcache.NewCachedItem(func(ctx context.Context) (bool, error) {
-		return true, nil
-	})
-
-	// Get a value from cache1 to generate a version.
-	result1 := cache1.Get(rootCtx, concurrentcache.AnyVersion)
-	require.NoError(t, result1.Error)
-
-	// Attempt to use the version from cache1 on cache2, which should panic.
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Errorf("expected panic but did not occur")
-		}
-
-		require.Equal(t, "[programming error]: provided minVersion does not correspond to the current cache; don't mix CacheVersions across caches", r)
-	}()
-
-	cache2.Get(rootCtx, result1.NextVersion)
-}
-
 // CacheVersion can be used to force values in the cache to be re-fetched.
 // There are 3 mechanisms:
 // 1. set minVersion=AnyVersion, will return a cached or non-cached value

--- a/test/cached_map_test.go
+++ b/test/cached_map_test.go
@@ -167,34 +167,6 @@ func TestMapError(t *testing.T) {
 	require.Equal(t, map[string]int{"key1": 1, "key2": 1}, counts)
 }
 
-func TestMapPanic(t *testing.T) {
-	rootCtx := context.Background()
-
-	cache1 := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (bool, error) {
-		return true, nil
-	})
-
-	cache2 := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (bool, error) {
-		return true, nil
-	})
-
-	// Get a value from cache1 to generate a version.
-	result1 := cache1.Get(rootCtx, "key1", concurrentcache.AnyVersion)
-	require.NoError(t, result1.Error)
-
-	// Attempt to use the version from cache1 on cache2, which should panic.
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Errorf("expected panic but did not occur")
-		}
-
-		require.Equal(t, "[programming error]: provided minVersion does not correspond to the current (cache, key) combo; don't mix CacheVersions across items", r)
-	}()
-
-	cache2.Get(rootCtx, "key1", result1.NextVersion)
-}
-
 // CacheVersion can be used to force values in the cache to be re-fetched.
 // There are 3 mechanisms:
 // 1. set minVersion=AnyVersion, will return a cached or non-cached value


### PR DESCRIPTION
Switch from per-key, per-cache versions to global versions.
This will allow us to support more advanced use cases in the future (eg. invalidating results that come from a combination of caches & keys).