### PR TITLE
Add NewWorkerContext option and provide implementation that mutates logger

### DIFF
--- a/cached.go
+++ b/cached.go
@@ -17,8 +17,25 @@ limitations under the License.
 package concurrentcache
 
 import (
+	"context"
+
 	versionsinternal "github.com/go418/concurrentcache/internal/versions"
 )
+
+// NewWorkerContext is a function that creates a new context for the worker.
+// It receives the context passed to the Get call (without the cancel) and
+// returns the context for the worker and a function that will be called when
+// the Get call is canceled before the worker finishes.
+type NewWorkerContext func(getCtxWithoutCancel context.Context) (worker context.Context, getDetached func())
+
+func defaultWorkerContext(fn NewWorkerContext) NewWorkerContext {
+	if fn != nil {
+		return fn
+	}
+	return func(getCtxWithoutCancel context.Context) (context.Context, func()) {
+		return getCtxWithoutCancel, func() {}
+	}
+}
 
 type CacheVersion = versionsinternal.CacheVersion
 

--- a/cached_item.go
+++ b/cached_item.go
@@ -35,6 +35,13 @@ type CachedItem[V any] struct {
 
 	// Generator function that is called when the cached value is missing or out-of-date.
 	Generate ItemGenerator[V]
+
+	// NewWorkerContext is a function that creates a new context for the worker.
+	// It receives the context passed to the Get call (without the cancel) and
+	// returns the context for the worker and a function that will be called when
+	// the Get call is canceled before the worker finishes.
+	// This function is optional and will by default return the context passed to it.
+	NewWorkerContext NewWorkerContext
 }
 
 // ItemGenerator is a function that generates a value for a CachedItem.
@@ -94,9 +101,13 @@ func (c *CachedItem[V]) Get(ctx context.Context, minVersion CacheVersion) Result
 		return result
 	}
 
+	var getDetached func()
+
 	// If there is no worker running, create a new worker.
 	if worker == nil {
-		workerCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
+		var workerCtx context.Context
+		workerCtx, getDetached = defaultWorkerContext(c.NewWorkerContext)(context.WithoutCancel(ctx))
+		workerCtx, cancel := context.WithCancelCause(workerCtx)
 
 		worker = &cacheWorker[V]{
 			cachedValue: versionedValue[V]{
@@ -131,6 +142,10 @@ func (c *CachedItem[V]) Get(ctx context.Context, minVersion CacheVersion) Result
 
 		// Since we are not the last reader, we don't need to cancel the worker.
 		if rc > 0 {
+			if getDetached != nil {
+				getDetached()
+			}
+
 			return newFailedResult[V](context.Cause(ctx), minVersion)
 		}
 

--- a/cached_map.go
+++ b/cached_map.go
@@ -34,6 +34,13 @@ type CachedMap[K comparable, V any] struct {
 
 	// Generator function that is called when the cached value is missing or out-of-date.
 	Generate MapGenerator[K, V]
+
+	// NewWorkerContext is a function that creates a new context for the worker.
+	// It receives the context passed to the Get call (without the cancel) and
+	// returns the context for the worker and a function that will be called when
+	// the Get call is canceled before the worker finishes.
+	// This function is optional and will by default return the context passed to it.
+	NewWorkerContext NewWorkerContext
 }
 
 type cacheItem[V any] struct {
@@ -102,9 +109,13 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 		return result
 	}
 
+	var getDetached func()
+
 	// If there is no worker running, create a new worker.
 	if worker == nil {
-		workerCtx, cancel := context.WithCancelCause(context.WithoutCancel(ctx))
+		var workerCtx context.Context
+		workerCtx, getDetached = defaultWorkerContext(c.NewWorkerContext)(context.WithoutCancel(ctx))
+		workerCtx, cancel := context.WithCancelCause(workerCtx)
 
 		worker = &cacheWorker[V]{
 			cachedValue: versionedValue[V]{
@@ -141,6 +152,10 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 
 		// Since we are not the last reader, we don't need to cancel the worker.
 		if rc > 0 {
+			if getDetached != nil {
+				getDetached()
+			}
+
 			return newFailedResult[V](context.Cause(ctx), minVersion)
 		}
 

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,0 +1,5 @@
+module github.com/go418/concurrentcache/logger
+
+go 1.23.2
+
+require github.com/go-logr/logr v1.4.2

--- a/logger/go.sum
+++ b/logger/go.sum
@@ -1,0 +1,2 @@
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024 The go418 authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+)
+
+// NewWorkerContextWithLogger is a worker context constructor that can be passed to CachedMap or
+// CachedItem to create a new context for the worker based on the context passed to the Get call.
+// This implementation will modify the logger found in the context of the Get call to include
+// a new key-value pair that indicates if the worker is still attached to the Get call. The worker
+// is considered detached if the Get call was canceled and has returned before the worker logged
+// the message.
+func NewWorkerContextWithLogger(getCtxWithoutCancel context.Context) (context.Context, func()) {
+	logger, err := logr.FromContext(getCtxWithoutCancel)
+	if err != nil {
+		return getCtxWithoutCancel, func() {}
+	}
+
+	workerLogger := &loggerWrapper{LogSink: logger.GetSink()}
+	return logr.NewContext(
+			getCtxWithoutCancel,
+			logger.WithSink(workerLogger),
+		), func() {
+			workerLogger.detached.Store(true)
+		}
+}
+
+type loggerWrapper struct {
+	logr.LogSink
+	detached atomic.Bool
+}
+
+func (lw *loggerWrapper) Info(level int, msg string, keysAndValues ...any) {
+	newKeysAndValues := make([]any, 0, len(keysAndValues)+2)
+	newKeysAndValues = append(newKeysAndValues, "worker")
+	if lw.detached.Load() {
+		newKeysAndValues = append(newKeysAndValues, "detached")
+	} else {
+		newKeysAndValues = append(newKeysAndValues, "attached")
+	}
+	lw.LogSink.Info(level, msg, newKeysAndValues...)
+}
+
+func (lw *loggerWrapper) Error(err error, msg string, keysAndValues ...any) {
+	newKeysAndValues := make([]any, 0, len(keysAndValues)+2)
+	newKeysAndValues = append(newKeysAndValues, "worker")
+	if lw.detached.Load() {
+		newKeysAndValues = append(newKeysAndValues, "detached")
+	} else {
+		newKeysAndValues = append(newKeysAndValues, "attached")
+	}
+	lw.LogSink.Error(err, msg, newKeysAndValues...)
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,13 +1,18 @@
 module test
 
-go 1.22.5
+go 1.23.2
 
 replace github.com/go418/concurrentcache => ../
 
+replace github.com/go418/concurrentcache/logger => ../logger
+
 require (
+	github.com/go-logr/logr v1.4.2
 	github.com/go418/concurrentcache v0.0.0-00010101000000-000000000000
+	github.com/go418/concurrentcache/logger v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sync v0.7.0
+	k8s.io/klog/v2 v2.130.1
 )
 
 require (

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
@@ -10,3 +12,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=

--- a/test/logger_test.go
+++ b/test/logger_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The go418 authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrentcache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go418/concurrentcache"
+	"github.com/go418/concurrentcache/debug"
+	"github.com/go418/concurrentcache/logger"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestMapLogger(t *testing.T) {
+	rootCtx := context.Background()
+	testLogger := ktesting.NewLogger(t, ktesting.NewConfig(
+		ktesting.BufferLogs(true),
+	))
+	rootCtx = logr.NewContext(rootCtx, testLogger)
+
+	step1 := make(chan struct{})
+	step2 := make(chan struct{})
+	step3 := make(chan struct{})
+	step4 := make(chan struct{})
+	cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (struct{}, error) {
+		logger := logr.FromContextOrDiscard(ctx)
+
+		logger.Info("test log 1", "key", "value")
+		close(step1)
+		<-step3
+		logger.Info("test log 2", "key", "value")
+
+		return struct{}{}, nil
+	})
+	cache.NewWorkerContext = logger.NewWorkerContextWithLogger
+
+	get1Ctx, get1CtxCancel := context.WithCancel(rootCtx)
+	go func() {
+		result := cache.Get(get1Ctx, "key1", concurrentcache.AnyVersion)
+		require.ErrorContains(t, result.Error, "context canceled")
+		close(step3)
+	}()
+	go func() {
+		<-step1
+		result := cache.Get(debug.OnStartedWaiting(rootCtx, func() { close(step2) }), "key1", concurrentcache.AnyVersion)
+		require.NoError(t, result.Error)
+		close(step4)
+	}()
+
+	<-step2
+	get1CtxCancel()
+	<-step4
+
+	if testingLogger, ok := testLogger.GetSink().(ktesting.Underlier); ok {
+		buffer := testingLogger.GetBuffer()
+		require.Equal(t, `INFO test log 1 worker="attached"
+INFO test log 2 worker="detached"
+`, buffer.String())
+	}
+}
+
+func TestItemLogger(t *testing.T) {
+	rootCtx := context.Background()
+	testLogger := ktesting.NewLogger(t, ktesting.NewConfig(
+		ktesting.BufferLogs(true),
+	))
+	rootCtx = logr.NewContext(rootCtx, testLogger)
+
+	step1 := make(chan struct{})
+	step2 := make(chan struct{})
+	step3 := make(chan struct{})
+	step4 := make(chan struct{})
+	cache := concurrentcache.NewCachedItem(func(ctx context.Context) (struct{}, error) {
+		logger := logr.FromContextOrDiscard(ctx)
+
+		logger.Info("test log 1", "key", "value")
+		close(step1)
+		<-step3
+		logger.Info("test log 2", "key", "value")
+
+		return struct{}{}, nil
+	})
+	cache.NewWorkerContext = logger.NewWorkerContextWithLogger
+
+	get1Ctx, get1CtxCancel := context.WithCancel(rootCtx)
+	go func() {
+		result := cache.Get(get1Ctx, concurrentcache.AnyVersion)
+		require.ErrorContains(t, result.Error, "context canceled")
+		close(step3)
+	}()
+	go func() {
+		<-step1
+		result := cache.Get(debug.OnStartedWaiting(rootCtx, func() { close(step2) }), concurrentcache.AnyVersion)
+		require.NoError(t, result.Error)
+		close(step4)
+	}()
+
+	<-step2
+	get1CtxCancel()
+	<-step4
+
+	if testingLogger, ok := testLogger.GetSink().(ktesting.Underlier); ok {
+		buffer := testingLogger.GetBuffer()
+		require.Equal(t, `INFO test log 1 worker="attached"
+INFO test log 2 worker="detached"
+`, buffer.String())
+	}
+}


### PR DESCRIPTION
Adds a `NewWorkerContext` option to `CachedMap` and `CachedItem`, which lets you specify how the worker context should be constructed.

The new `github.com/go418/concurrentcache/logger` module provides an implementation that adds a `"worker":"detached"` or `"worker":"attached"` keypair to its log messages based on whether the `Get` call that created the worker is still waiting.