### PR TITLE
Add cache capacity to CachedMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - **Version-queryable cache**: you can request (1) any value (possibly cached), (2) a fresh
 value (not cached), (3) a value that is newer than a value returned previously.  
 *see [A version-queryable cache](#a-version-queryable-cache)*
+- **Finite sized**: the CachedMap has a max capacity of 1000 elements by default. LRU eviction is used
+when capacity is reached and this exposes evicted elements to be garbage collected by Go.
 
 ## Usage
 
@@ -31,22 +33,24 @@ import (
 
 func main() {
 	sharedValue := 0
-	cache := concurrentcache.NewCachedItem(func(ctx context.Context) (int, error) {
+	cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (int, error) {
 		// Simulate a long running operation.
 		time.Sleep(1 * time.Second)
+
+		fmt.Println("Generator function executed for key:", key)
 
 		// Update the shared value, we do not need to lock the value as the cache will
 		// ensure that there are no two simultaneous executions of this generator function.
 		sharedValue++
 
 		return sharedValue, nil
-	})
+	}, concurrentcache.WithCapacity(500))
 
 	// Requesting the value in parallel will only run the generator function once.
 	group := errgroup.Group{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		group.Go(func() error {
-			result := cache.Get(context.TODO(), concurrentcache.AnyVersion)
+			result := cache.Get(context.TODO(), "key1", concurrentcache.AnyVersion)
 			if result.Value != 1 {
 				panic("sharedValue should be 1")
 			}
@@ -64,7 +68,7 @@ func main() {
 	}
 
 	// Force the cache to refresh the value.
-	result := cache.Get(context.TODO(), concurrentcache.NonCachedVersion)
+	result := cache.Get(context.TODO(), "key1", concurrentcache.NonCachedVersion)
 	if result.Value != 2 {
 		panic("sharedValue should be 2")
 	}

--- a/cached.go
+++ b/cached.go
@@ -18,6 +18,8 @@ package concurrentcache
 
 import (
 	"context"
+	"runtime"
+	"weak"
 
 	versionsinternal "github.com/go418/concurrentcache/internal/versions"
 )
@@ -101,6 +103,24 @@ func (vv versionedValue[V]) toResult(isFromCache bool) Result[V] {
 		// of the result plus one, making it newer than the current version.
 		NextVersion: versionsinternal.NextVersion(vv.version),
 	}
+}
+
+type weakVersionedValue[V any] struct {
+	versionedValue[weak.Pointer[V]]
+	cleanup runtime.Cleanup
+}
+
+func (wvv weakVersionedValue[V]) strong() (versionedValue[V], *V, bool) {
+	strongPtr := wvv.value.Value()
+	if strongPtr == nil {
+		return versionedValue[V]{}, nil, false
+	}
+
+	return versionedValue[V]{
+		value:   *strongPtr,
+		err:     wvv.err,
+		version: wvv.version,
+	}, strongPtr, true
 }
 
 type cacheWorker[V any] struct {

--- a/cached_map.go
+++ b/cached_map.go
@@ -19,9 +19,12 @@ package concurrentcache
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
+	"weak"
 
 	debuginternal "github.com/go418/concurrentcache/internal/debug"
+	lruinternal "github.com/go418/concurrentcache/internal/lru"
 	versionsinternal "github.com/go418/concurrentcache/internal/versions"
 )
 
@@ -31,6 +34,7 @@ import (
 type CachedMap[K comparable, V any] struct {
 	mu    sync.Mutex
 	items map[K]cacheItem[V]
+	lru   *lruinternal.LRU[*V]
 
 	// generate function that is called when the cached value is missing or out-of-date.
 	generate MapGenerator[K, V]
@@ -40,8 +44,9 @@ type CachedMap[K comparable, V any] struct {
 }
 
 type cacheItem[V any] struct {
-	cachedValue versionedValue[V]
+	cachedValue weakVersionedValue[V]
 	worker      *cacheWorker[V]
+	lruEl       *lruinternal.Element[*V]
 }
 
 // MapGenerator is a function that generates a value for a CachedMap.
@@ -51,13 +56,16 @@ type cacheItem[V any] struct {
 type MapGenerator[K comparable, V any] func(ctx context.Context, key K) (V, error)
 
 func NewCachedMap[K comparable, V any](generateMissingValue MapGenerator[K, V], opts ...MapCacheOption) *CachedMap[K, V] {
-	options := mapCacheOptions{}
+	options := mapCacheOptions{
+		capacity: 1000,
+	}
 	for _, opt := range opts {
 		opt.applyMapCache(&options)
 	}
 
 	return &CachedMap[K, V]{
 		items:    make(map[K]cacheItem[V]),
+		lru:      lruinternal.New[*V](options.capacity),
 		generate: generateMissingValue,
 		options:  options,
 	}
@@ -83,8 +91,15 @@ func (c *CachedMap[K, V]) Get(ctx context.Context, key K, minVersion CacheVersio
 	{
 		cachedValue := item.cachedValue
 		if !cachedValue.isZero() && cachedValue.isNotOlderThan(minVersion) {
-			defer c.mu.Unlock() // Unlock after reading the cached value.
-			return cachedValue.toResult(true)
+			if result, strongPtr, ok := cachedValue.strong(); ok {
+				// if we found a cached value, make sure we have a strong reference
+				// in the LRU
+				item.lruEl = c.lru.MoveToFront(item.lruEl, strongPtr)
+				c.items[key] = item
+
+				defer c.mu.Unlock() // Unlock after reading the cached value.
+				return result.toResult(true)
+			}
 		}
 		nextVersion = cachedValue.newer()
 	}
@@ -205,7 +220,20 @@ func (c *CachedMap[K, V]) run(ctx context.Context, worker *cacheWorker[V], key K
 
 	// Update the cache value if the worker was not canceled
 	if worker.nrGetCallsWaiting > 0 {
-		item.cachedValue = worker.returnValue
+		item.cachedValue.cleanup.Stop() // Disable previous cleanup.
+		ptrValue := &worker.returnValue.value
+		item.cachedValue = weakVersionedValue[V]{
+			versionedValue: versionedValue[weak.Pointer[V]]{
+				value:   weak.Make(ptrValue),
+				err:     worker.returnValue.err,
+				version: worker.returnValue.version,
+			},
+			cleanup: runtime.AddCleanup(ptrValue, c.delete, deleteKey[K]{
+				key:          key,
+				exactVersion: worker.returnValue.version,
+			}),
+		}
+		item.lruEl = c.lru.MoveToFront(item.lruEl, ptrValue)
 	}
 
 	c.items[key] = item
@@ -265,9 +293,40 @@ func (c *CachedMap[K, V]) setLocked(key K, value V, minVersion CacheVersion) {
 		return
 	}
 
-	item.cachedValue = versionedValue[V]{
-		value:   value,
-		version: minVersion,
+	item.cachedValue.cleanup.Stop() // Disable previous cleanup.
+	ptrValue := &value
+	item.cachedValue = weakVersionedValue[V]{
+		versionedValue: versionedValue[weak.Pointer[V]]{
+			value:   weak.Make(ptrValue),
+			version: minVersion,
+		},
+		cleanup: runtime.AddCleanup(ptrValue, c.delete, deleteKey[K]{
+			key:          key,
+			exactVersion: minVersion,
+		}),
 	}
+	item.lruEl = c.lru.MoveToFront(item.lruEl, ptrValue)
 	c.items[key] = item
+}
+
+type deleteKey[K comparable] struct {
+	key          K
+	exactVersion CacheVersion
+}
+
+func (c *CachedMap[K, V]) delete(key deleteKey[K]) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	item, ok := c.items[key.key]
+	if !ok {
+		return
+	}
+
+	// Only delete the item if the cached value is at the exact version.
+	if item.cachedValue.version != key.exactVersion {
+		return
+	}
+
+	delete(c.items, key.key)
 }

--- a/examples/example1.go
+++ b/examples/example1.go
@@ -29,22 +29,24 @@ import (
 // generator function, even when made in parallel.
 func example1() {
 	sharedValue := 0
-	cache := concurrentcache.NewCachedItem(func(ctx context.Context) (int, error) {
+	cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (int, error) {
 		// Simulate a long running operation.
 		time.Sleep(1 * time.Second)
+
+		fmt.Println("Generator function executed for key:", key)
 
 		// Update the shared value, we do not need to lock the value as the cache will
 		// ensure that there are no two simultaneous executions of this generator function.
 		sharedValue++
 
 		return sharedValue, nil
-	})
+	}, concurrentcache.WithCapacity(500))
 
 	// Requesting the value in parallel will only run the generator function once.
 	group := errgroup.Group{}
 	for range 10 {
 		group.Go(func() error {
-			result := cache.Get(context.TODO(), concurrentcache.AnyVersion)
+			result := cache.Get(context.TODO(), "key1", concurrentcache.AnyVersion)
 			if result.Value != 1 {
 				panic("sharedValue should be 1")
 			}
@@ -62,7 +64,7 @@ func example1() {
 	}
 
 	// Force the cache to refresh the value.
-	result := cache.Get(context.TODO(), concurrentcache.NonCachedVersion)
+	result := cache.Get(context.TODO(), "key1", concurrentcache.NonCachedVersion)
 	if result.Value != 2 {
 		panic("sharedValue should be 2")
 	}

--- a/internal/lru/lru.go
+++ b/internal/lru/lru.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The go418 authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lru
+
+// inspired by "container/list"
+
+type Element[V any] struct {
+	next, prev *Element[V]
+	value      V
+}
+
+type LRU[V any] struct {
+	root              Element[V]
+	remainingCapacity int
+}
+
+func New[V any](capacity int) *LRU[V] {
+	list := new(LRU[V])
+
+	list.root.next = &list.root
+	list.root.prev = &list.root
+	list.remainingCapacity = capacity
+
+	return list
+}
+
+func (l *LRU[V]) insert(e, at *Element[V]) *Element[V] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	l.remainingCapacity--
+	return e
+}
+
+func (l *LRU[V]) remove(e *Element[V]) {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	var zero V
+	e.value = zero // drop reference
+	l.remainingCapacity++
+}
+
+func (l *LRU[V]) move(e, at *Element[V]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+func (l *LRU[V]) MoveToFront(e *Element[V], value V) *Element[V] {
+	if e == nil {
+		// insert new element with the value
+		e = &Element[V]{value: value}
+	} else {
+		e.value = value
+	}
+
+	// already at front
+	if l.root.next == e {
+		return e
+	}
+
+	if e.next == nil || e.prev == nil {
+		// evict last element if at capacity
+		if l.remainingCapacity == 0 && l.root.prev != &l.root {
+			l.remove(l.root.prev)
+		}
+
+		// if still at capacity (LRU has 0 capacity), return
+		if l.remainingCapacity == 0 {
+			return nil
+		}
+
+		// element not in list, insert it
+		return l.insert(e, &l.root)
+	}
+
+	// remove and re-insert at front
+	l.move(e, &l.root)
+	return e
+}

--- a/options.go
+++ b/options.go
@@ -27,6 +27,12 @@ type cacheOptions struct {
 
 type mapCacheOptions struct {
 	cacheOptions
+
+	// capacity is the maximum number of items to keep in the cache.
+	// LRU eviction is used when the capacity is exceeded. An evicted item
+	// will be garbage collected if there are no other references to it.
+	// Defaults to 1000.
+	capacity int
 }
 
 type itemCacheOptions struct {
@@ -50,6 +56,18 @@ func WithMapNewWorkerContext(fn NewWorkerContext) interface {
 	})
 }
 
+// Set the capacity of the map cache, any value less than
+// 0 will be ignored.
+func WithCapacity(capacity int) MapCacheOption {
+	return mapCacheOptionFunc(func(opts *mapCacheOptions) {
+		if capacity < 0 {
+			return
+		}
+
+		opts.capacity = capacity
+	})
+}
+
 // cacheOptionFunc is a helper type to create cache options.
 
 type cacheOptionFunc func(*cacheOptions)
@@ -63,4 +81,14 @@ func (f cacheOptionFunc) applyItemCache(opts *itemCacheOptions) {
 
 func (f cacheOptionFunc) applyMapCache(opts *mapCacheOptions) {
 	f(&opts.cacheOptions)
+}
+
+// mapCacheOptionFunc is a helper type to create map cache options.
+
+type mapCacheOptionFunc func(*mapCacheOptions)
+
+var _ MapCacheOption = mapCacheOptionFunc(nil)
+
+func (f mapCacheOptionFunc) applyMapCache(opts *mapCacheOptions) {
+	f(opts)
 }

--- a/test/cached_map_test.go
+++ b/test/cached_map_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -424,4 +426,193 @@ func FuzzTestMapGet(f *testing.F) {
 
 		testMapGet(t, nrConcurrentGetCallsNonCanceled, nrConcurrentGetCallsCanceled, nrKeys, nrRepeats, allAtSameTime)
 	})
+}
+
+// Weak cache should allow values to be garbage collected and removed from the cache.
+func TestMapWeakCache(t *testing.T) {
+	type testCase struct {
+		capacity int
+		run      func(t *testing.T, cache *concurrentcache.CachedMap[string, returnValue])
+	}
+
+	getKey := func(
+		t *testing.T,
+		cache *concurrentcache.CachedMap[string, returnValue],
+		minVersion concurrentcache.CacheVersion,
+		key string, count int, cached bool,
+	) returnValue {
+		result := cache.Get(t.Context(), key, minVersion)
+		require.Equal(t, returnValue{requestedKey: key, count: count}, result.Value)
+		require.NoError(t, result.Error)
+		require.Equal(t, cached, result.FromCache)
+		return result.Value
+	}
+
+	for i, tc := range []testCase{
+		{
+			capacity: 1,
+			run: func(t *testing.T, cache *concurrentcache.CachedMap[string, returnValue]) {
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 1, false)
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 2, false)
+
+				// Force GC and wait until the weakly cached value is collected and removed.
+				for range 5 {
+					runtime.GC()
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 2, true) // last generated value should still be cached
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 3, false)
+			},
+		},
+		{
+			capacity: 1,
+			run: func(t *testing.T, cache *concurrentcache.CachedMap[string, returnValue]) {
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 1, false)
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 2, false)
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 1, true)
+
+				// Force GC and wait until the weakly cached value is collected and removed.
+				for range 5 {
+					runtime.GC()
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 1, true) // last accessed value should still be cached
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 3, false)
+			},
+		},
+		{
+			capacity: 2,
+			run: func(t *testing.T, cache *concurrentcache.CachedMap[string, returnValue]) {
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 1, false)
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 2, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key2", 3, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key1", 4, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key2", 5, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key2", 6, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key2", 7, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key1", 8, false)
+				getKey(t, cache, concurrentcache.NonCachedVersion, "key1", 9, false)
+
+				// Force GC and wait until the weakly cached value is collected and removed.
+				for range 5 {
+					runtime.GC()
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				// Both values should still be cached as capacity is 2.
+				getKey(t, cache, concurrentcache.AnyVersion, "key1", 9, true)
+				getKey(t, cache, concurrentcache.AnyVersion, "key2", 7, true)
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
+			count := 0
+			cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (returnValue, error) {
+				count++
+				return returnValue{
+					requestedKey: key,
+					count:        count,
+				}, nil
+			}, concurrentcache.WithCapacity(tc.capacity))
+
+			tc.run(t, cache)
+		})
+	}
+}
+
+func TestMapWeakCacheStress(t *testing.T) {
+	const capacity = 100
+
+	count := int64(0)
+	cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) (int64, error) {
+		return atomic.AddInt64(&count, 1), nil
+	}, concurrentcache.WithCapacity(capacity))
+
+	for _, minVersion := range []concurrentcache.CacheVersion{
+		concurrentcache.AnyVersion,
+		concurrentcache.NonCachedVersion,
+	} {
+		// Add 5000 unique entries in parallel
+		{
+			group, gctx := errgroup.WithContext(t.Context())
+			for i := range 5000 {
+				group.Go(func() error {
+					key := fmt.Sprintf("key-%d", i+1)
+					result := cache.Get(gctx, key, minVersion)
+					require.NoError(t, result.Error)
+					return nil
+				})
+			}
+			require.NoError(t, group.Wait())
+		}
+
+		// Re-access the first entries that fit within capacity in parallel
+		{
+			group, gctx := errgroup.WithContext(t.Context())
+			for i := range 5000 {
+				group.Go(func() error {
+					key := fmt.Sprintf("key-%d", (i%capacity)+1)
+					result := cache.Get(gctx, key, minVersion)
+					require.NoError(t, result.Error)
+					return nil
+				})
+			}
+
+			// Perform GC while the goroutines are running.
+			for range 100 {
+				runtime.GC()
+				time.Sleep(1 * time.Millisecond)
+			}
+
+			require.NoError(t, group.Wait())
+		}
+
+		// Force GC and wait until the weakly cached value is collected and removed.
+		for range 5 {
+			runtime.GC()
+			time.Sleep(5 * time.Millisecond)
+		}
+
+		// All keys that we fetched last (within capacity) should be cached.
+		for i := range capacity {
+			key := fmt.Sprintf("key-%d", i+1)
+			result := cache.Get(t.Context(), key, concurrentcache.AnyVersion)
+			require.NoError(t, result.Error)
+			require.True(t, result.FromCache)
+		}
+	}
+}
+
+// Ensure the memory footprint of a weak cache remains bounded after GC.
+func TestMapWeakCacheMemory(t *testing.T) {
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	cache := concurrentcache.NewCachedMap(func(ctx context.Context, key string) ([]byte, error) {
+		return make([]byte, 1*1024*1024 /* 1MB per value */), nil
+	}, concurrentcache.WithCapacity(0))
+
+	for i := range 1000 {
+		cache.Get(t.Context(), fmt.Sprintf("k%d", i), concurrentcache.AnyVersion)
+	}
+
+	// Force GC and measure memory used by the process after weak values are collectible.
+	for range 3 {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// Allow a reasonable headroom (10MB) for allocations unrelated to the cache.
+	const threshold = uint64(10 << 20)
+	used := after.HeapAlloc
+	base := before.HeapAlloc
+	if used > base+threshold {
+		t.Fatalf("weak cache memory footprint too large: before=%d after=%d diff=%d", base, used, used-base)
+	}
 }


### PR DESCRIPTION
Introduces a max capacity to the CachedMap.
This prevents unbound memory growth in long-running processes.

How it works:
- cache values are now referenced using a [weak pointer](https://pkg.go.dev/weak#Pointer)
- we keep an additional reference to the cache value for all items in an internal LRU cache
- only when an item is evicted from the internal LRU cache, it can be garbage collected

```go
// example: this cache has a max capacity of 500 values
cache := concurrentcache.NewCachedMap(
    func(ctx context.Context, key string) (int, error) { ... },
    concurrentcache.WithCapacity(500),
)
```